### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple Language
 
+[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fsimple-language.svg)](https://mcptoplist.com/server/pulsemcp%2Fsimple-language)
+
 [![Production Ready](https://img.shields.io/badge/status-production%20ready-brightgreen)](doc/archive/release/PRODUCTION_READY_SUMMARY.md)
 [![Tests](https://img.shields.io/badge/tests-4067%2F4067%20passing-brightgreen)](doc/09_report/session/full_test_suite_results_2026-02-14.md)
 [![Multiplatform Bootstrap](https://github.com/ormastes/simple/actions/workflows/rust-bootstrap-multiplatform.yml/badge.svg)](.github/workflows/rust-bootstrap-multiplatform.yml)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,919 MCP servers across the major
registries, and **Simple Language** is currently ranked **#931**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fsimple-language.svg)](https://mcptoplist.com/server/pulsemcp%2Fsimple-language)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Simple Language!
